### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/nateshrajofficial/2c0381e3-5992-4fe9-9036-8a7ef9288e01/f8c8f3e5-d808-4408-bf12-5d188f6c4447/_apis/work/boardbadge/1035635c-bc83-4fd9-94c9-6041f0b15332)](https://dev.azure.com/nateshrajofficial/2c0381e3-5992-4fe9-9036-8a7ef9288e01/_boards/board/t/f8c8f3e5-d808-4408-bf12-5d188f6c4447/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://dev.azure.com/nateshrajofficial/2c0381e3-5992-4fe9-9036-8a7ef9288e01/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.